### PR TITLE
Add renderer.js, ipc, and react

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,5 +5,8 @@
     <title></title>
   </head>
   <body>
+    <div id="container"></div>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+    <script src="renderer.js" type="text/babel"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -3,6 +3,9 @@ const ioHook = require('iohook');
 const menubar = require('menubar');
 const moment = require('moment');
 const momentDurationFormatSetup = require('moment-duration-format');
+const url = require('url')
+const path = require('path');
+const { ipcMain } = require('electron')
 
 momentDurationFormatSetup(moment);
 
@@ -21,20 +24,29 @@ function handleKeyboardEvent(event) {
   }
 
   streak.keys++;
+  mb.window.webContents.send('current-streak', streak.keys);
 }
-
+let minStreak = 10;
 function handleMouseEvent(event) {
   if (!streak.active) { return };
 
   const currentTime = Date.now();
   const duration = moment.duration(currentTime - streak.startTime).format('h [hours], m [minutes], s [seconds]');
 
-  const notification = new Notification({
-    title: 'Streak broken!',
-    body: `You typed ${streak.keys} keys during that streak, lasting ${duration}`
-  });
+  if (streak.keys > minStreak) {
+    mb.window.webContents.send('streak-broken', {
+      keystrokes: streak.keys,
+      duration,
+      timestamp: Date.now()
+    });
 
-  notification.show();
+    const notification = new Notification({
+      title: 'Streak broken!',
+      body: `You typed ${streak.keys} keys during that streak, lasting ${duration}`
+    });
+
+    notification.show();
+  }
 
   streak.active = false;
   streak.keys = 0;
@@ -49,7 +61,19 @@ function registerShortcut() {
 }
 
 function ready () {
-  let index = 0;
+  mb.showWindow();
+}
+
+const windowRendered = () => {
+
+  mb.window.loadURL(url.format({
+    pathname: path.join(__dirname, 'index.html'),
+    protocol: 'file:',
+    slashes: true
+  }));
+
+  // ✋ 🚫 🐛
+  // mb.window.openDevTools();
 
   ioHook.on('keyup', handleKeyboardEvent);
 
@@ -63,6 +87,22 @@ function ready () {
   globalShortcut.register('CommandOrControl+K', registerShortcut);
 }
 
+// startup health-check pings
+ipcMain.on('asynchronous-message', (event, arg) => {
+  console.log(arg) // prints "ping"
+  event.sender.send('asynchronous-reply', 'pong')
+})
+
+ipcMain.on('min-streak', (event, arg) => {
+  console.log('new min-streak: ', arg);
+  minStreak = arg;
+});
+
+ipcMain.on('quit', (event, arg) => {
+  mb.app.quit();
+});
+
 mb.on('ready', ready);
 mb.on('after-show', () => { isMenuBarOpen = true; });
 mb.on('after-hide', () => { isMenuBarOpen = false; });
+mb.on('after-create-window', windowRendered)

--- a/main.js
+++ b/main.js
@@ -3,9 +3,9 @@ const ioHook = require('iohook');
 const menubar = require('menubar');
 const moment = require('moment');
 const momentDurationFormatSetup = require('moment-duration-format');
-const url = require('url')
+const url = require('url');
 const path = require('path');
-const { ipcMain } = require('electron')
+const { ipcMain } = require('electron');
 
 momentDurationFormatSetup(moment);
 
@@ -90,8 +90,8 @@ const windowRendered = () => {
 // startup health-check pings
 ipcMain.on('asynchronous-message', (event, arg) => {
   console.log(arg) // prints "ping"
-  event.sender.send('asynchronous-reply', 'pong')
-})
+  event.sender.send('asynchronous-reply', 'pong');
+});
 
 ipcMain.on('min-streak', (event, arg) => {
   console.log('new min-streak: ', arg);
@@ -105,4 +105,4 @@ ipcMain.on('quit', (event, arg) => {
 mb.on('ready', ready);
 mb.on('after-show', () => { isMenuBarOpen = true; });
 mb.on('after-hide', () => { isMenuBarOpen = false; });
-mb.on('after-create-window', windowRendered)
+mb.on('after-create-window', windowRendered);

--- a/package-lock.json
+++ b/package-lock.json
@@ -649,6 +649,14 @@
       "resolved": "https://registry.npmjs.org/electron-positioner/-/electron-positioner-3.0.0.tgz",
       "integrity": "sha1-Gjt1ycweKd03xmOyP9h21P+rmZY="
     },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.23"
+      }
+    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -1764,6 +1772,15 @@
         "semver": "5.5.0"
       }
     },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
+    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -1806,8 +1823,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-keys": {
       "version": "0.4.0",
@@ -2045,6 +2061,28 @@
         "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
+      }
+    },
+    "react": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
+      "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
+      "requires": {
+        "fbjs": "0.8.17",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.1"
+      }
+    },
+    "react-dom": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
+      "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
+      "requires": {
+        "fbjs": "0.8.17",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.1"
       }
     },
     "read-pkg": {
@@ -2639,6 +2677,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "ua-parser-js": {
+      "version": "0.7.18",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+      "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,6 +105,11 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -455,6 +460,11 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -648,6 +658,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/electron-positioner/-/electron-positioner-3.0.0.tgz",
       "integrity": "sha1-Gjt1ycweKd03xmOyP9h21P+rmZY="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.23"
+      }
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -1010,6 +1028,20 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fbjs": {
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "requires": {
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.18"
+      }
+    },
     "fd-slicer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
@@ -1253,7 +1285,6 @@
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-      "dev": true,
       "requires": {
         "safer-buffer": "2.1.2"
       }
@@ -1445,6 +1476,11 @@
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -1469,6 +1505,15 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.4"
+      }
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -1478,8 +1523,7 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
       "version": "3.12.0",
@@ -1598,6 +1642,14 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -1762,6 +1814,15 @@
       "integrity": "sha512-pUlswqpHQ7zGPI9lGjZ4XDNIEUDbHxsltfIRb7dTnYdhgHWHOcB0MLZKLoCz6UMcGzSPG5wGl1HODZVQAUsH6w==",
       "requires": {
         "semver": "5.5.0"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
       }
     },
     "normalize-package-data": {
@@ -2007,6 +2068,23 @@
         "through2": "0.2.3"
       }
     },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "requires": {
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -2051,7 +2129,10 @@
       "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
       "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
       "requires": {
-        "object-assign": "4.1.1"
+        "fbjs": "0.8.17",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.2"
       }
     },
     "react-dom": {
@@ -2059,7 +2140,10 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
       "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
       "requires": {
-        "object-assign": "4.1.1"
+        "fbjs": "0.8.17",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.2"
       }
     },
     "read-pkg": {
@@ -2226,8 +2310,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "segfault-handler": {
       "version": "1.0.0",
@@ -2242,6 +2325,11 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -2655,6 +2743,11 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "ua-parser-js": {
+      "version": "0.7.18",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+      "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2696,6 +2789,11 @@
         "exec-sh": "0.2.1",
         "minimist": "1.2.0"
       }
+    },
+    "whatwg-fetch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "which": {
       "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -649,14 +649,6 @@
       "resolved": "https://registry.npmjs.org/electron-positioner/-/electron-positioner-3.0.0.tgz",
       "integrity": "sha1-Gjt1ycweKd03xmOyP9h21P+rmZY="
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "0.4.23"
-      }
-    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -1772,15 +1764,6 @@
         "semver": "5.5.0"
       }
     },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
-    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -2068,10 +2051,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
       "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
       "requires": {
-        "fbjs": "0.8.17",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.1"
+        "object-assign": "4.1.1"
       }
     },
     "react-dom": {
@@ -2079,10 +2059,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
       "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
       "requires": {
-        "fbjs": "0.8.17",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.1"
+        "object-assign": "4.1.1"
       }
     },
     "read-pkg": {
@@ -2677,11 +2654,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
-    },
-    "ua-parser-js": {
-      "version": "0.7.18",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-      "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "iohook": "^0.1.16",
     "menubar": "^5.2.3",
     "moment": "^2.22.1",
-    "moment-duration-format": "^2.2.2"
+    "moment-duration-format": "^2.2.2",
+    "react": "^16.4.1",
+    "react-dom": "^16.4.1"
   },
   "iohook": {
     "targets": [

--- a/renderer.js
+++ b/renderer.js
@@ -28,12 +28,12 @@ class MainComponent extends React.Component {
   }
 
   handleMinStreakChange(event) {
-    this.setState({ value: event.target.value });
+    this.setState({ minStreak: event.target.value });
   }
 
   handleSubmit(event) {
     event.preventDefault();
-    ipcRenderer.send('min-streak', this.state.value);
+    ipcRenderer.send('min-streak', this.state.minStreak);
   }
   currentStreak(event, arg) {
     this.setState(() => ({ currentStreak: arg }))

--- a/renderer.js
+++ b/renderer.js
@@ -1,10 +1,10 @@
-const { ipcRenderer } = require('electron')
+const { ipcRenderer } = require('electron');
 
 // start up heath-check
 ipcRenderer.on('asynchronous-reply', (event, arg) => {
   console.log(arg) // prints "pong"
 })
-ipcRenderer.send('asynchronous-message', 'ping')
+ipcRenderer.send('asynchronous-message', 'ping');
 
 // front end
 const React = require('react');
@@ -38,12 +38,16 @@ class MainComponent extends React.Component {
   currentStreak(event, arg) {
     this.setState(() => ({ currentStreak: arg }))
   }
-  streakBroken(event, arg) {
-    // const { keystrokes, duration, timestamp } = arg
+  
+  streakBroken(event, { keystrokes, duration, timestamp }) {
     this.setState(() => ({
       streaks: [
         ...this.state.streaks,
-        arg
+        {
+          keystrokes,
+          duration,
+          timestamp
+        }
       ]
     }));
   }

--- a/renderer.js
+++ b/renderer.js
@@ -1,0 +1,89 @@
+const { ipcRenderer } = require('electron')
+
+// start up heath-check
+ipcRenderer.on('asynchronous-reply', (event, arg) => {
+  console.log(arg) // prints "pong"
+})
+ipcRenderer.send('asynchronous-message', 'ping')
+
+// front end
+const React = require('react');
+const ReactDOM = require('react-dom');
+const moment = require('moment');
+
+class MainComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      currentStreak: 0,
+      streaks: [],
+      minStreak: 10,
+    };
+
+    this.handleMinStreakChange = this.handleMinStreakChange.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.quit = this.quit.bind(this);
+    ipcRenderer.on('current-streak', this.currentStreak.bind(this));
+    ipcRenderer.on('streak-broken', this.streakBroken.bind(this));
+  }
+
+  handleMinStreakChange(event) {
+    this.setState({ value: event.target.value });
+  }
+
+  handleSubmit(event) {
+    event.preventDefault();
+    ipcRenderer.send('min-streak', this.state.value);
+  }
+  currentStreak(event, arg) {
+    this.setState(() => ({ currentStreak: arg }))
+  }
+  streakBroken(event, arg) {
+    // const { keystrokes, duration, timestamp } = arg
+    this.setState(() => ({
+      streaks: [
+        ...this.state.streaks,
+        arg
+      ]
+    }));
+  }
+  quit() {
+    ipcRenderer.send('quit', true);
+  }
+
+  render() {
+    return (
+      <div>
+        <form onSubmit={this.handleSubmit}>
+          <label>
+            minimum keystrokes for notification: 
+            <input type="number" value={this.state.minStreak} onChange={this.handleMinStreakChange} style={{width: 80}} />
+          </label>
+          <input type="submit" value="Set" />
+        </form>
+        <div>current streak: {this.state.currentStreak}</div>
+        <div>
+          <ul>
+            {this.state.streaks &&
+              this.state.streaks.length >= 1
+              ? (
+                <div>
+                  {this.state.streaks.sort((a, b) =>  b.keystrokes - a.keystrokes )
+                    .map((streak, index) => {
+                      return (
+                        <li key={index}>
+                          {streak.keystrokes} keys, {streak.duration}.  {moment(streak.timestamp).format("ddd, hA")}
+                        </li>
+                      )
+                    })}
+                </div>
+              ) : null}
+          </ul>
+        </div>
+        <button onClick={this.quit}>quit</button>
+      </div>
+    )
+  }
+}
+
+ReactDOM.render(<MainComponent />, document.getElementById('container'));


### PR DESCRIPTION
@sdsanders added two things:

- ipc for sending messages between the main and render processes.
- react, ReactDOM to render it without building. Had to set the `<script>`'s type to `text/bable` in order to use JSX in `renderer.js`. Brought bable in with a script tag, idk how else to make bable available there. There is an npm package for `bable-standalone`, couldn't get it to work though.

There is a high score list in the client, ipc messages are just added to an array in the component's state. This works but I think this kind of state is better suited for `main.js`. That way we could send out notifications when you broke your previous high score, etc.

fixes:
https://github.com/sdsanders/kill-the-mouse/issues/2, https://github.com/sdsanders/kill-the-mouse/issues/4, https://github.com/sdsanders/kill-the-mouse/issues/5, https://github.com/sdsanders/kill-the-mouse/issues/9